### PR TITLE
Fix an issue with EvalEnvironment (wrong method name)

### DIFF
--- a/ggplot/components/layer.py
+++ b/ggplot/components/layer.py
@@ -126,7 +126,7 @@ class layer(object):
             aesthetics['group'] = self.group
 
         env = EvalEnvironment.capture(eval_env=plot.plot_env)
-        env.add_outer_namespace({'factor': pd.Categorical})
+        env.with_outer_namespace({'factor': pd.Categorical})
 
         evaled = pd.DataFrame(index=data.index)
         settings = False  # Indicate manual settings within aes()


### PR DESCRIPTION
Fix for:

Simple call:

```
p = ggplot(data_, aes(x='res1', y='res2', size='SpecNum')) \
    + geom_point(alpha=0.4, color='#268bd2')
```

crashes because `EvalEnvironment` in `patsy` has [`with_outer_namespace` method](https://github.com/pydata/patsy/blob/master/patsy/eval.py#L147) instead of `add_outer_namespace`